### PR TITLE
I have created the `ratchetwrk` unit for you by copying the `spark` u…

### DIFF
--- a/020.glops/06.ratchetwrk.unit/buz/createRatchetwrk.buzz.ts
+++ b/020.glops/06.ratchetwrk.unit/buz/createRatchetwrk.buzz.ts
@@ -1,0 +1,43 @@
+import { RatchetwrkModel } from "../ratchetwrk.model";
+import RatchetwrkBit from "../fce/ratchetwrk.bit";
+import State from "../../99.core/state";
+import OrbBit from "../fce/orb.bit";
+
+//import * as ActClr from "../../../000.earth/03.color.unit/color.action";
+import * as ActSpk from "../../03.ratchetwrk.unit/ratchetwrk.action";
+import * as ActCol from "../../97.collect.unit/collect.action";
+import * as ActBus from "../../99.bus.unit/bus.action";
+
+import * as ActVrt from "../../act/vurt.action"
+import * as ActDsk from "../../act/disk.action"
+import * as ActPvt from "../../act/pivot.action"
+
+import EtherealBit from "../fce/talent/etheric.bit";
+
+var bit, val, idx, dex, lst, dat, src;
+
+export const createRatchetwrk = async (cpy: RatchetwrkModel, bal: RatchetwrkBit, ste: State) => {
+
+    var dat: OrbBit = { idx: bal.idx, src: bal.src }
+
+    var etri:EtherealBit = { bliyte:null, grusit:null, flxuow:null, kldadu:null };
+    dat.bit = etri;
+
+  //  bit = await ste.hunt( ActClr.BASKET_COLOR, {})
+  //  dat.bit.bliyte = bit.clrBit.dat
+
+  //  bit = await ste.hunt( ActClr.BASKET_COLOR, {})
+  //  dat.bit.flxuow = bit.clrBit.dat
+
+  //  bit = await ste.hunt( ActClr.BASKET_COLOR, {})
+  //  dat.bit.grusit = bit.clrBit.dat
+
+  //  bit = await ste.hunt( ActClr.BASKET_COLOR, {})
+  //  dat.bit.kldadu = bit.clrBit.dat
+
+    dat
+
+    bal.slv({ spkBit: { idx: "create-ratchetwrk", dat } });
+
+    return cpy;
+};

--- a/020.glops/06.ratchetwrk.unit/buz/ratchetwrk.buzz.ts
+++ b/020.glops/06.ratchetwrk.unit/buz/ratchetwrk.buzz.ts
@@ -1,0 +1,76 @@
+import * as ActSpk from "../../03.ratchetwrk.unit/ratchetwrk.action";
+import * as ActCol from "../../97.collect.unit/collect.action";
+import * as ActBus from "../../99.bus.unit/bus.action";
+
+
+import * as ActVrt from "../../act/vurt.action"
+import * as ActDsk from "../../act/disk.action"
+import * as ActPvt from "../../act/pivot.action"
+
+
+var bit, val, idx, dex, lst, dat, src;
+
+export const initRatchetwrk = async (cpy: RatchetwrkModel, bal: RatchetwrkBit, ste: State) => {
+
+    //set up colors
+    //src = '000.color.name.json'
+    //bit = await ste.bus(ActDsk.READ_DISK, { src: './data/color-list/' + src })
+    //var colorList = bit.dskBit.dat;
+
+    //lst = JSON.parse(colorList)
+
+    //bit = await ste.bus(ActClr.WRITE_COLOR, { idx: 'clr00', dat: { lst } });
+
+    //var staveDataLoc = './data/stave/'
+    //src = staveDataLoc + '002.genisi.txt';
+
+    //bit = await ste.bus(ActStv.WRITE_STAVE, { src });
+
+    bal.slv({ intBit: { idx: "init-ratchetwrk" } });
+
+    return cpy;
+};
+
+
+export const updateRatchetwrk = async (cpy: RatchetwrkModel, bal: RatchetwrkBit, ste: State) => {
+    return cpy;
+};
+
+
+export const readRatchetwrk = async (cpy: RatchetwrkModel, bal: RatchetwrkBit, ste: State) => {
+
+    if (bal.idx == null) bal.idx = 'spk00';
+    bit = await ste.hunt(ActCol.READ_COLLECT, { idx: bal.idx, bit: ActSpk.CREATE_RATCHETWRK })
+
+    bal.slv({ spkBit: { idx: "read-ratchetwrk", dat: bit.clcBit.dat } });
+    return cpy;
+};
+
+export const writeRatchetwrk = async (cpy: RatchetwrkModel, bal: RatchetwrkBit, ste: State) => {
+
+    bit = await ste.hunt(ActCol.WRITE_COLLECT, { idx: bal.idx, src: bal.src, dat: bal.dat, bit: ActSpk.CREATE_RATCHETWRK })
+
+    if (bal.slv != null) bal.slv({ spkBit: { idx: "write-ratchetwrk", dat: bit.clcBit.dat } });
+    return cpy;
+};
+
+
+
+export const removeRatchetwrk = async (cpy: RatchetwrkModel, bal: RatchetwrkBit, ste: State) => {
+    debugger
+    return cpy;
+};
+
+
+export const deleteRatchetwrk = async (cpy: RatchetwrkModel, bal: RatchetwrkBit, ste: State) => {
+    debugger
+    return cpy;
+};
+
+
+
+
+import { RatchetwrkModel } from "../ratchetwrk.model";
+import RatchetwrkBit from "../fce/ratchetwrk.bit";
+import State from "../../99.core/state";
+import OrbBit from "../fce/orb.bit";

--- a/020.glops/06.ratchetwrk.unit/fce/orb.bit.ts
+++ b/020.glops/06.ratchetwrk.unit/fce/orb.bit.ts
@@ -1,0 +1,7 @@
+import EthericBit from "./talent/etheric.bit";
+
+export default interface OrbBit {
+ idx:string;
+ src?:string;
+ bit?:EthericBit
+}

--- a/020.glops/06.ratchetwrk.unit/fce/ratchetwrk.bit.ts
+++ b/020.glops/06.ratchetwrk.unit/fce/ratchetwrk.bit.ts
@@ -1,0 +1,10 @@
+
+export default interface RatchetwrkBit {
+    idx: string;
+    src?: string;
+    val?: number;
+    dat?: any;
+    slv?: Function;
+    bit?: any;
+    lst?: any[];
+}

--- a/020.glops/06.ratchetwrk.unit/fce/ratchetwrk.interface.ts
+++ b/020.glops/06.ratchetwrk.unit/fce/ratchetwrk.interface.ts
@@ -1,0 +1,8 @@
+import  RatchetwrkBit  from "./ratchetwrk.bit";
+
+export default interface Ratchetwrk {
+ // idx:string;
+ // ratchetwrkBitList: RatchetwrkBit[];
+ // ratchetwrkBits:any;
+
+}

--- a/020.glops/06.ratchetwrk.unit/fce/talent/authentic.bit.ts
+++ b/020.glops/06.ratchetwrk.unit/fce/talent/authentic.bit.ts
@@ -1,0 +1,6 @@
+
+export default interface AuthenticBit {
+    direction: string;
+    purpose: string;
+    cohesion: string;
+}

--- a/020.glops/06.ratchetwrk.unit/fce/talent/capacitive.bit.ts
+++ b/020.glops/06.ratchetwrk.unit/fce/talent/capacitive.bit.ts
@@ -1,0 +1,6 @@
+
+export default interface CapacitiveBit {
+    cognition: string;
+    vocabulary: string;
+    reminiscence: string;
+}

--- a/020.glops/06.ratchetwrk.unit/fce/talent/etheric.bit.ts
+++ b/020.glops/06.ratchetwrk.unit/fce/talent/etheric.bit.ts
@@ -1,0 +1,7 @@
+
+export default interface EthericBit {
+    bliyte: string;
+    grusit: string;
+    flxuow: string;
+    kldadu: string
+}

--- a/020.glops/06.ratchetwrk.unit/fce/talent/imaginative.bit.ts
+++ b/020.glops/06.ratchetwrk.unit/fce/talent/imaginative.bit.ts
@@ -1,0 +1,6 @@
+
+export default interface ImaginativeBit {
+    style: string;
+    ingenuity: string;
+    vision: string;
+}

--- a/020.glops/06.ratchetwrk.unit/fce/talent/legitimate.bit.ts
+++ b/020.glops/06.ratchetwrk.unit/fce/talent/legitimate.bit.ts
@@ -1,0 +1,6 @@
+
+export default interface LegitimateBit {
+    fidelity: string;
+    recognition: string;
+    sovereignty: string;
+}

--- a/020.glops/06.ratchetwrk.unit/fce/talent/pivotal.bit.ts
+++ b/020.glops/06.ratchetwrk.unit/fce/talent/pivotal.bit.ts
@@ -1,0 +1,6 @@
+
+export default interface PivotalBit {
+    contribution: string;
+    gravity: string;
+    providence: string;
+}

--- a/020.glops/06.ratchetwrk.unit/fce/talent/reactive.bit.ts
+++ b/020.glops/06.ratchetwrk.unit/fce/talent/reactive.bit.ts
@@ -1,0 +1,6 @@
+
+export default interface ReactiveBit {
+    discernment: string;
+    impulse: string;
+    sensation: string;
+}

--- a/020.glops/06.ratchetwrk.unit/fce/talent/significant.bit.ts
+++ b/020.glops/06.ratchetwrk.unit/fce/talent/significant.bit.ts
@@ -1,0 +1,6 @@
+
+export default interface SignificantBit {
+    force: string;
+    charge: string;
+    scale: string;
+}

--- a/020.glops/06.ratchetwrk.unit/fce/talent/vigorous.bit.ts
+++ b/020.glops/06.ratchetwrk.unit/fce/talent/vigorous.bit.ts
@@ -1,0 +1,6 @@
+
+export default interface VigorousBit {
+    pizazz: string;
+    oomph: string;
+    zing: string;
+}

--- a/020.glops/06.ratchetwrk.unit/ratchetwrk.action.ts
+++ b/020.glops/06.ratchetwrk.unit/ratchetwrk.action.ts
@@ -1,0 +1,53 @@
+import { Action } from "../99.core/interface/action.interface";
+import  SparkBit  from "./fce/ratchetwrk.bit";
+
+// Spark actions
+
+export const INIT_SPARK = "[Spark action] Init Spark";
+export class InitSpark implements Action {
+ readonly type = INIT_SPARK;
+ constructor(public bale: SparkBit) {}
+}
+
+export const UPDATE_SPARK = "[Spark action] Update Spark";
+export class UpdateSpark implements Action {
+ readonly type = UPDATE_SPARK;
+ constructor(public bale: SparkBit) {}
+}
+
+export const READ_SPARK = "[Read action] Read Spark";
+ export class ReadSpark implements Action {
+ readonly type = READ_SPARK;
+ constructor(public bale: SparkBit) {}
+ }
+
+export const WRITE_SPARK = "[Write action] Write Spark";
+ export class WriteSpark implements Action {
+ readonly type = WRITE_SPARK;
+ constructor(public bale: SparkBit) {}
+ }
+
+export const REMOVE_SPARK = "[Remove action] Remove Spark";
+ export class RemoveSpark implements Action {
+ readonly type = REMOVE_SPARK;
+ constructor(public bale: SparkBit) {}
+ }
+
+export const DELETE_SPARK = "[Delete action] Delete Spark";
+ export class DeleteSpark implements Action {
+ readonly type = DELETE_SPARK;
+ constructor(public bale: SparkBit) {}
+ }
+
+export const CREATE_SPARK = "[Create action] Create Spark";
+ export class CreateSpark implements Action {
+ readonly type = CREATE_SPARK;
+ constructor(public bale: SparkBit) {}
+ }
+
+export type Actions = | InitSpark | UpdateSpark
+| ReadSpark
+| WriteSpark
+| RemoveSpark
+| DeleteSpark
+| CreateSpark

--- a/020.glops/06.ratchetwrk.unit/ratchetwrk.buzzer.ts
+++ b/020.glops/06.ratchetwrk.unit/ratchetwrk.buzzer.ts
@@ -1,0 +1,7 @@
+export { initRatchetwrk  } from "./buz/ratchetwrk.buzz";
+export { updateRatchetwrk  } from "./buz/ratchetwrk.buzz";
+export { readRatchetwrk  } from "./buz/ratchetwrk.buzz";
+export { writeRatchetwrk  } from "./buz/ratchetwrk.buzz";
+export { removeRatchetwrk  } from "./buz/ratchetwrk.buzz";
+export { deleteRatchetwrk  } from "./buz/ratchetwrk.buzz";
+export { createRatchetwrk  } from "./buz/createRatchetwrk.buzz";

--- a/020.glops/06.ratchetwrk.unit/ratchetwrk.model.ts
+++ b/020.glops/06.ratchetwrk.unit/ratchetwrk.model.ts
@@ -1,0 +1,8 @@
+import Ratchetwrk from "./fce/ratchetwrk.interface";
+import RatchetwrkBit from "./fce/ratchetwrk.interface";
+
+export class RatchetwrkModel implements Ratchetwrk {
+ //idx:string;
+ //ratchetwrkBitList: RatchetwrkBit[] = [];
+ //ratchetwrkBits: any = {};
+}

--- a/020.glops/06.ratchetwrk.unit/ratchetwrk.reduce.ts
+++ b/020.glops/06.ratchetwrk.unit/ratchetwrk.reduce.ts
@@ -1,0 +1,34 @@
+import * as clone from "clone-deep";
+import * as Act from "./ratchetwrk.action";
+import { RatchetwrkModel } from "./ratchetwrk.model";
+import * as Buzz from "./ratchetwrk.buzzer";
+import State from "../99.core/state";
+
+export function reducer(model: RatchetwrkModel = new RatchetwrkModel(), act: Act.Actions,  state?: State ) {
+ switch (act.type) {
+
+ case Act.UPDATE_RATCHETWRK:
+ return Buzz.updateRatchetwrk(clone(model), act.bale, state);
+
+ case Act.INIT_RATCHETWRK:
+ return Buzz.initRatchetwrk(clone(model), act.bale, state);
+
+case Act.READ_RATCHETWRK:
+ return Buzz.readRatchetwrk(clone(model), act.bale, state);
+
+case Act.WRITE_RATCHETWRK:
+ return Buzz.writeRatchetwrk(clone(model), act.bale, state);
+
+case Act.REMOVE_RATCHETWRK:
+ return Buzz.removeRatchetwrk(clone(model), act.bale, state);
+
+case Act.DELETE_RATCHETWRK:
+ return Buzz.deleteRatchetwrk(clone(model), act.bale, state);
+
+case Act.CREATE_RATCHETWRK:
+ return Buzz.createRatchetwrk(clone(model), act.bale, state);
+
+ default:
+ return model;
+ }
+}

--- a/020.glops/06.ratchetwrk.unit/ratchetwrk.unit.ts
+++ b/020.glops/06.ratchetwrk.unit/ratchetwrk.unit.ts
@@ -1,0 +1,8 @@
+import State from "../99.core/state";
+
+
+export default class RatchetwrkUnit {
+
+ constructor(state: State) {
+ }
+}


### PR DESCRIPTION
…nit.

Here's what I did:
- Copied the `spark` unit from `010.sower` to `020.glops` and renamed it to `ratchetwrk`.
- Renamed the unit directory to `06.ratchetwrk.unit`.
- Renamed all files and directories within the unit to use `ratchetwrk` instead of `spark`.
- Updated the content of the files to use `ratchetwrk` and `Ratchetwrk` instead of `spark` and `Spark`.

Please note: I was unable to modify `020.glops/06.ratchetwrk.unit/ratchetwrk.action.ts` due to a technical issue. You will need to fix this file manually.