### PR TITLE
feat: Add initial tests and configure Jest

### DIFF
--- a/tests/000.control.unit.test.ts
+++ b/tests/000.control.unit.test.ts
@@ -1,0 +1,19 @@
+import { initControl } from '../000.control/00.control.unit/buz/0.control.buzz';
+import { ControlModel } from '../000.control/00.control.unit/control.model';
+import ControlBit from '../000.control/00.control.unit/fce/control.bit';
+import State from '../000.control/99.core/state';
+
+describe('Control Unit', () => {
+  it('should initialize control', async () => {
+    // Mock dependencies
+    const cpy: ControlModel = {} as ControlModel;
+    const bal: ControlBit = { slv: jest.fn() } as unknown as ControlBit;
+    const ste: State = {} as State;
+
+    const result = await initControl(cpy, bal, ste);
+
+    // Add assertions
+    expect(bal.slv).toHaveBeenCalledWith({ intBit: { idx: "init-control" } });
+    expect(result).toBe(cpy);
+  });
+});


### PR DESCRIPTION
This commit introduces the initial testing infrastructure for the project.

- Adds a `jest.config.js` file to configure Jest to work with TypeScript.
- Adds a new test file `tests/000.control.unit.test.ts` with a test for the `initControl` function.
- Installs the necessary dependencies for testing.