### PR TITLE
Fix: Configure Jest and Babel to correctly handle TypeScript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "stringify": "^5.2.0"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.28.3",
+    "@babel/preset-react": "^7.27.1",
+    "@babel/preset-typescript": "^7.27.1",
     "@rsbuild/core": "^1.2.8",
     "@rsbuild/plugin-react": "^1.1.0",
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
This commit fixes a "Missing initializer in const declaration" error that was occurring when running tests. The error was caused by a misconfiguration of Jest and Babel, which were not correctly parsing TypeScript files.

This commit introduces the following changes:
- Adds a `jest.config.js` file to configure Jest to use `ts-jest` for TypeScript files.
- Adds a `babel.config.js` file to configure Babel with the necessary presets for TypeScript and React.
- Adds the required `@babel/preset-env`, `@babel/preset-typescript`, and `@babel/preset-react` dev dependencies to `package.json`.